### PR TITLE
Fix bug with step conversion to integer in slice.js

### DIFF
--- a/lib/slice.js
+++ b/lib/slice.js
@@ -2,8 +2,8 @@ module.exports = function(arr, start, end, step) {
 
   var len = arr.length;
 
+  step = step? integer(step) : 1;
   if (step === 0) throw new Error("step cannot be zero");
-  step = step || 1;
 
   // normalize negative values
   start = start < 0 ? len + start : start;


### PR DESCRIPTION
Fix bug when step is undefined or a string value, step is never converted to integer, causing the for loop index to hold undefined or string value after ` i += step `. The for loop will never terminate on the condition ` i != end `