### PR TITLE
Fix infinite loop bug with slice() when step arg is defined

### DIFF
--- a/lib/slice.js
+++ b/lib/slice.js
@@ -3,7 +3,7 @@ module.exports = function(arr, start, end, step) {
   var len = arr.length;
 
   if (step === 0) throw new Error("step cannot be zero");
-  step = step || 1;
+  step = step ? integer(step) : 1;
 
   // normalize negative values
   start = start < 0 ? len + start : start;
@@ -24,6 +24,7 @@ module.exports = function(arr, start, end, step) {
   var result = [];
 
   for (var i = start; i != end; i += step) {
+    if ((step < 0 && i <= end) || (step > 0 && i >= end)) break;
     result.push(arr[i]);
   }
 

--- a/test/query.js
+++ b/test/query.js
@@ -170,6 +170,11 @@ suite('query', function() {
     assert.deepEqual(results, data.store.book.slice(0,3));
   });
 
+  test('slice with step > 1', function() {
+    var results = jp.query(data, "$.store.book[0:4:2]");
+    assert.deepEqual(results, [ data.store.book[0], data.store.book[2]]);
+  });
+
   test('union of subscript string literal keys', function() {
     var results = jp.nodes(data, "$.store['book','bicycle']");
     assert.deepEqual(results, [


### PR DESCRIPTION
- If step is defined as a string value, which is the use case with the parser/handlers, step is never converted to integer, and loop index is coerced into string after ` i += step` causing the loop termination condition to never fire
- If step is converted into an integer and abs(step) > 1, the loop termination condition of `i != end` is again never fired

Added test to cover scenario: "$.store.book[0:4:2]"

This will close #6