### PR TITLE
Recover from parse failure by reinitializing parser AST with each call…

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,9 +6,10 @@ var Parser = function() {
   var parser = new JisonParser(grammar);
 
   parser.yy.ast = _ast;
-  _ast.initialize();
-
-  return parser;
+  return { parse: function(path) {
+    parser.yy.ast.initialize();
+    return parser.parse(path);
+  }};
 
 };
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -140,4 +140,13 @@ suite('parse-negative', function() {
     assert.throws(function() { var path = jp.parse('()') })
   });
 
+  test('parser ast is reinitialized after parse() throws', function() {
+    assert.throws(function() { var path = jp.parse('store.book...') })
+    var path = jp.parse('$..price');
+    assert.deepEqual(path, [
+      { "expression": { "type": "root", "value": "$" } },
+      { "expression": { "type": "identifier", "value": "price" }, "operation": "member", "scope": "descendant"}
+    ])
+  });
+
 });


### PR DESCRIPTION
This prevents garbage left overs in the result from last failed run.

This will close #9