### PR TITLE
Implement #12

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,66 @@
+module.exports = function (grunt) {
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        outputFolder: "dist",
+
+        browserify: {
+            main: {
+                src: ['index.js'],
+                dest: '<%= outputFolder %>/<%= pkg.name %>.js',
+                options: {
+                    banner: '/*! <%= pkg.name %> <%= pkg.version %> */\n',
+                    alias: {
+                        "jsonpath": "./index.js"
+                    },
+                    require: [
+                        /**
+                         * When running in Node, we require('./aesprim') and that module takes care of monkey-patching esprima
+                         * using resolve, path finding, etc...
+                         * Anyways, Browserify doesn't support "resolve", so we need to trick the module. We'll actually be
+                         * returning a verbatim, non-modified "esprima" when the code runs require('./aesprim').
+                         * That is ok because we will modify the "esprima" source code right after the bundle process, via
+                         * the postBundleCB callback.
+                         */
+                        ["esprima", {expose: "./aesprim"}]
+                    ],
+                    ignore: [
+                        'file',
+                        'system',
+                        'source-map',
+                        'estraverse',
+                        'escodegen',
+                        'underscore',
+                        'reflect',
+                        'JSONSelect',
+                        './lib/aesprim.js'
+                        //'assert' //can't remove because of lib/index.js,
+                    ],
+                    postBundleCB: function(err, src, next) {
+                        /**
+                         * This is ugly, but we need to make "esprima" understand '@' as a valid character.
+                         * It's either this or bundle a copy of the library with those few bytes of changes.
+                         */
+                        src = src.toString("utf8").replace(/(function isIdentifierStart\(ch\) {\s+return)/m, '$1 (ch == 0x40) || ');
+                        next(err, new Buffer(src, "utf8"));
+                    }
+                }
+            }
+        },
+
+        uglify: {
+            options: {
+                banner: '/*! <%= pkg.name %> <%= pkg.version %> */\n'
+            },
+            build: {
+                src: '<%= outputFolder %>/<%= pkg.name %>.js',
+                dest: '<%= outputFolder %>/<%= pkg.name %>.min.js'
+            }
+        }
+
+    });
+
+    grunt.loadNpmTasks('grunt-browserify');
+    grunt.loadNpmTasks('grunt-contrib-uglify')
+    grunt.registerTask('default', ['browserify', 'uglify']);
+
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "devDependencies": {
     "mocha": "2.1.0",
     "jscs": "1.10.0",
-    "jshint": "2.6.0"
+    "jshint": "2.6.0",
+    "grunt": "~0.4.1",
+    "grunt-browserify": "latest",
+    "grunt-contrib-uglify": "latest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch implements #12 via Browserify. The entire thing works the following way:

Browserify scans all the libraries used by this package, but because what Browserify
does is actually scan all raw "require"s, we need to tell it which packages it
shouldn't care about.

After running quite some tests, I think all those modules can be excluded safely:

* file
* system
* source-map
* estraverse
* escodegen
* reflect
* JSONSelect
* underscore (1)
* ./lib/aesprim.js (2)

After scanning all the required modules, Browserify "compiles" them in a single
file, next to some shims and some basic emulation of Node ("require" itself, for
example).

There are some things we need to change here, before getting that module running
into the browser.

(1) `underscore`. This should be excluded because it just doesn't make any sense
shipping the bundle with it. Underscore can be included in the browser via
`<script>` tag, which will

* allow other libraries use it
* not increase the size of the (already big enough) jsonpath.js file

Because of this, we just tell Browserify to ignore all the `require("underscore")`
stratements. And because this module was written using `_` and not some other funky
character/alias, this just works automagically.

(2) `aesprim.js`. This module monkey-patches the "esprima" module, allowing it to
accept '@' as a valid character. There is a problem with that: Browserify doesn't
support 'resolve', which is used by "aesprim" to find the "esprima" module. And
because of that, we need to find another way to  make the "aesprima" helper work.
The best thing I could think of (and imho, it's quite clever) is to do the following
things:

* modify the source code of the "esprima" module in the "postBundleCB" callback of
Browserify, which happens just before the entire browser-compatible JS code is
generated.
* make Browserify return a copy of "esprima" every time a `require("./aesprim")` is
ran. And because we did the previous step, we'll be actually running the "esprima"
code that allows the '@' character.

Finally, the grunt file takes the generated JS code and minifies it.

### Numbers:

I managed to trim down the size of the output file to 306.4KB (139.9KB minified).
It's quite big, but it's the best thing I could manage to do.

### Can we trim that down more?

Currently, the `assert` module is used in `lib/index.js`. It we refactor that code
and make it use vanilla JS checks, we could remove another ~25KB of the size of
the output file.

### Which modules are bundled in the output JS?

All the files from the `lib` folder and those files:

* `/usr/local/lib/node_modules/browserify/lib/_empty.js`
* `/tmp/jsonpath/node_modules/static-eval/index.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/util/typal.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/ebnf.js`
* `/usr/local/lib/node_modules/browserify/node_modules/process/browser.js`
* `/usr/local/lib/node_modules/browserify/node_modules/util/support/isBufferBrowser.js`
* `/usr/local/lib/node_modules/browserify/node_modules/path-browserify/index.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/lexer.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/util/set.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/util/bnf-parser.js`
* `/usr/local/lib/node_modules/browserify/node_modules/inherits/inherits_browser.js`
* `/usr/local/lib/node_modules/browserify/node_modules/util/util.js`
* `/usr/local/lib/node_modules/browserify/node_modules/assert/assert.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/util/lex-parser.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/jisonlex.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison/bnf.js`
* `/tmp/jsonpath/node_modules/jison/lib/jison.js`

### What do I need to run to generate the browser-compatible JS code?

After running `npm install` (as I added a few dependencies) the only thing you need
to do is run `grunt`. Grunt will take care of everything else, from patching "esprima"
to generating the minified version of the file.