### PR TITLE
Fix missing 'require.resolve' in browserify build

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -1,6 +1,7 @@
 var dict = require('./dict');
 var fs = require('fs');
 fs.readFileSync = fs.readFileSync || function() {}
+require.resolve = require.resolve || function() {}
 
 var grammar = {
 


### PR DESCRIPTION
Fixes #26 
It safe because `fs.readFileSync` already disabled so file couldn't be read anyway.
@dchester This issue blocks me, can you please review it?