### PR TITLE
Updated dependencies and introduced delete option with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Returns the parent of the first matching element.
 
 #### jp.apply(obj, pathExpression, fn)
 
-Runs the supplied function `fn` on each matching element, and replaces each matching element with the return value from the function.  The function accepts the value of the matching element as its only parameter.  Returns matching nodes with their updated values.
+Runs the supplied application function `fn` on each matching element, and replaces each matching element with the return value from the function.  The function accepts the value of the matching element as its only parameter.  Returns matching nodes with their updated values.
 
 
 ```javascript
@@ -165,6 +165,8 @@ var nodes = jp.apply(data, '$..author', function(value) { return value.toUpperCa
 //   { path: ['$', 'store', 'book', 3, 'author'], value: 'J. R. R. TOLKIEN' }
 // ]
 ```
+
+If the supplied application function returns the special value `:delete:` the node will be deleted and not updated as is otherwise the default case.
 
 #### jp.parse(pathExpression)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,8 +42,9 @@ JSONPath.prototype.apply = function(obj, string, fn) {
     var key = node.path.pop();
     var parent = this.value(obj, this.stringify(node.path));
     var val = node.value = fn.call(obj, parent[key]);
+
     if (val === ':delete:') {
-      delete parent[key]
+      delete parent[key];
     } else {
       parent[key] = val;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,11 @@ JSONPath.prototype.apply = function(obj, string, fn) {
     var key = node.path.pop();
     var parent = this.value(obj, this.stringify(node.path));
     var val = node.value = fn.call(obj, parent[key]);
-    parent[key] = val;
+    if (val === ':delete:') {
+      delete parent[key]
+    } else {
+      parent[key] = val;
+    }
   }, this);
 
   return nodes;

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "generate": "node bin/generate_parser.js > generated/parser.js"
   },
   "dependencies": {
-    "esprima": "1.2.2",
-    "jison": "0.4.13",
-    "static-eval": "0.2.3",
-    "underscore": "1.7.0"
+    "esprima": "^3.0.0",
+    "jison": "^0.4.17",
+    "static-eval": "^1.1.1",
+    "underscore": "^1.8.3"
   },
   "browser": {
     "./lib/aesprim.js": "./generated/aesprim-browser.js"
@@ -24,7 +24,7 @@
     "grunt-contrib-uglify": "0.9.1",
     "jscs": "1.10.0",
     "jshint": "2.6.0",
-    "mocha": "2.1.0"
+    "mocha": "^3.1.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "generate": "node bin/generate_parser.js > generated/parser.js"
   },
   "dependencies": {
-    "esprima": "^3.0.0",
+    "esprima": "^2.0.0",
     "jison": "^0.4.17",
     "static-eval": "^1.1.1",
     "underscore": "^1.8.3"

--- a/test/sugar.js
+++ b/test/sugar.js
@@ -17,6 +17,12 @@ suite('sugar', function() {
     assert.equal(data.z.a, 101);
   });
 
+  test('apply method deletes value', function() {
+    var data = { a: 1, b: 2, c: 3, z: { a: 100, b: 200 } };
+    jp.apply(data, '$..a', function(v) { return ':delete:' });
+    assert.ok(Object.keys(data).indexOf('a') < 0);
+  });
+
   test('apply method applies survives structural changes', function() {
     var data = {a: {b: [1, {c: [2,3]}]}};
     jp.apply(data, '$..*[?(@.length > 1)]', function(array) {


### PR DESCRIPTION
All tests pass. Note, when trying to upgrade to Esprima 3:

```
     Error: Line 1: Unexpected token ILLEGAL
      at ErrorHandler.constructError (lib/aesprim.js:3378:22)
      at ErrorHandler.createError (lib/aesprim.js:3396:27)
      at ErrorHandler.throwError (lib/aesprim.js:3404:21)
      at Scanner.throwUnexpectedToken (lib/aesprim.js:3487:28)
      at Scanner.scanPunctuator (lib/aesprim.js:4008:19)
      at Scanner.lex (lib/aesprim.js:4610:22)
      at Parser.nextToken (lib/aesprim.js:634:30)
      at new Parser (lib/aesprim.js:474:15)
      at Object.parse (lib/aesprim.js:115:19)
      at Handlers.subscript-child-filter_expression (lib/handlers.js:111:23)
```

So the `aesprima` hack, trying to inject `@` as a valid identifier fails. Likely because it is now a valid symbol for decorators? So I had to downgrade to esprima 2 to make it work. Still better than before ;)
