### PR TITLE
fix import typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "mocha -u tdd test && jscs lib && jshint lib",
     "generate": "node bin/generate_parser.js > generated/parser.js"
   },
+  "main": "jsonpath.js",
   "dependencies": {
     "esprima": "1.2.2",
     "jison": "0.4.13",


### PR DESCRIPTION
Use @types/jsonpath problem with ```import jp from 'jsonpath';``` with rollup

```
[22:58:46]  rollup: Treating 'fs' as external dependency 
[22:58:47]  rollup: Treating 'module' as external dependency 
[22:58:51]  rollup: No name was provided for external module 'fs' in options.globals – guessing 'require$$1' 
[22:58:51]  rollup: No name was provided for external module 'module' in options.globals – guessing 'module$1' 
```