### PR TITLE
Fix for running jsonpath in browser.

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -1,8 +1,5 @@
 var dict = require('./dict');
 var fs = require('fs');
-fs.readFileSync = fs.readFileSync || function() {}
-require.resolve = require.resolve || function() {}
-
 var grammar = {
 
     lex: {
@@ -99,10 +96,11 @@ var grammar = {
         STRING_LITERAL: [
                 [ 'QQ_STRING', "$$ = $1" ],
                 [ 'Q_STRING',  "$$ = $1" ] ]
-    },
-
-    moduleInclude: fs.readFileSync(require.resolve("../include/module.js")),
-    actionInclude: fs.readFileSync(require.resolve("../include/action.js"))
+    }
 };
+if (fs.readFileSync) {
+  grammar.moduleInclude = fs.readFileSync(require.resolve("../include/module.js"));
+  grammar.actionInclude = fs.readFileSync(require.resolve("../include/action.js"));
+}
 
 module.exports = grammar;


### PR DESCRIPTION
I do not want credit for this. This fix is created by blobcat, but he/she never created any pull-request for it. So I did. (Ref: https://github.com/dchester/jsonpath/issues/50)
This is tested using webpack for browser environment, and in Node. 