### PR TITLE
Fix inexistent name union

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -80,7 +80,9 @@ Handlers.prototype._fns = {
       var _component = { operation: 'subscript', scope: 'child', expression: component.expression };
       var handler = this.resolve(_component);
       var _results = handler(_component, partial);
-      results = results.concat(_results);
+      if (_results) {
+        results = results.concat(_results);
+      }
     }, this);
 
     return unique(results);

--- a/test/query.js
+++ b/test/query.js
@@ -250,6 +250,42 @@ suite('query', function() {
       { path: ['$', 'store', 'book', 3, 'price'], value: data.store.book[3].price }
     ]);
   });
+  
+  test('union of subscript integer four keys, including an inexistent one, followed by union of subscript string literal three keys', function() {
+    var results = jp.nodes(data, "$.store.book[0,1,2,3,151]['title','author','price']");
+    assert.deepEqual(results, [
+      { path: ['$', 'store', 'book', 0, 'title'], value: data.store.book[0].title },
+      { path: ['$', 'store', 'book', 0, 'author'], value: data.store.book[0].author },
+      { path: ['$', 'store', 'book', 0, 'price'], value: data.store.book[0].price },
+      { path: ['$', 'store', 'book', 1, 'title'], value: data.store.book[1].title },
+      { path: ['$', 'store', 'book', 1, 'author'], value: data.store.book[1].author },
+      { path: ['$', 'store', 'book', 1, 'price'], value: data.store.book[1].price },
+      { path: ['$', 'store', 'book', 2, 'title'], value: data.store.book[2].title },
+      { path: ['$', 'store', 'book', 2, 'author'], value: data.store.book[2].author },
+      { path: ['$', 'store', 'book', 2, 'price'], value: data.store.book[2].price },
+      { path: ['$', 'store', 'book', 3, 'title'], value: data.store.book[3].title },
+      { path: ['$', 'store', 'book', 3, 'author'], value: data.store.book[3].author },
+      { path: ['$', 'store', 'book', 3, 'price'], value: data.store.book[3].price }
+    ]);
+  });
+  
+  test('union of subscript integer three keys followed by union of subscript string literal three keys, followed by inexistent literal key', function() {
+    var results = jp.nodes(data, "$.store.book[0,1,2,3]['title','author','price','fruit']");
+    assert.deepEqual(results, [
+      { path: ['$', 'store', 'book', 0, 'title'], value: data.store.book[0].title },
+      { path: ['$', 'store', 'book', 0, 'author'], value: data.store.book[0].author },
+      { path: ['$', 'store', 'book', 0, 'price'], value: data.store.book[0].price },
+      { path: ['$', 'store', 'book', 1, 'title'], value: data.store.book[1].title },
+      { path: ['$', 'store', 'book', 1, 'author'], value: data.store.book[1].author },
+      { path: ['$', 'store', 'book', 1, 'price'], value: data.store.book[1].price },
+      { path: ['$', 'store', 'book', 2, 'title'], value: data.store.book[2].title },
+      { path: ['$', 'store', 'book', 2, 'author'], value: data.store.book[2].author },
+      { path: ['$', 'store', 'book', 2, 'price'], value: data.store.book[2].price },
+      { path: ['$', 'store', 'book', 3, 'title'], value: data.store.book[3].title },
+      { path: ['$', 'store', 'book', 3, 'author'], value: data.store.book[3].author },
+      { path: ['$', 'store', 'book', 3, 'price'], value: data.store.book[3].price }
+    ]);
+  });
 
   test('union of subscript 4 array slices followed by union of subscript string literal three keys', function() {
     var results = jp.nodes(data, "$.store.book[0:1,1:2,2:3,3:4]['title','author','price']");


### PR DESCRIPTION
This should fix #52 

When using a union subscript where some of the name identifiers may not exist, return the results of those which actually exist, in a similar fashion to what happens when doing the same thing using unions for array indices.

