### PR TITLE
Detect circular references and return early

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -192,8 +192,8 @@ function traverser(recurse) {
 
     var results = [];
 
-    var seen = new Set();
-    var descend = function(value, path) {
+    var descend = function(value, path, seen) {
+      seen = new Set(seen)
 
       if (is_array(value)) {
         value.forEach(function(element, index) {
@@ -205,7 +205,7 @@ function traverser(recurse) {
         value.forEach(function(element, index) {
           if (results.length >= count) { return }
           if (recurse) {
-            descend(element, path.concat(index));
+            descend(element, path.concat(index), seen);
           }
         });
       } else if (is_object(value)) {
@@ -223,7 +223,7 @@ function traverser(recurse) {
         this.keys(value).forEach(function(k) {
           if (results.length >= count) { return }
           if (recurse) {
-            descend(value[k], path.concat(k));
+            descend(value[k], path.concat(k), seen);
           }
         });
       }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -192,6 +192,7 @@ function traverser(recurse) {
 
     var results = [];
 
+    var seen = new Set();
     var descend = function(value, path) {
 
       if (is_array(value)) {
@@ -208,6 +209,11 @@ function traverser(recurse) {
           }
         });
       } else if (is_object(value)) {
+        if (seen.has(value)) {
+          return;
+        } else {
+          seen.add(value);
+        }
         this.keys(value).forEach(function(k) {
           if (results.length >= count) { return }
           if (passable(k, value[k], ref)) {

--- a/test/query.js
+++ b/test/query.js
@@ -360,6 +360,13 @@ suite('query', function() {
     obj.circularReference = obj;
     var results = jp.query(obj, '$..*');
     assert.deepEqual(results, ['bar', obj]);
+
+    var obj = {};
+    var o = { foo: 'bar' }
+    obj.foo = o
+    obj.bar = o
+    var results = jp.query(obj, '$..*');
+    assert.deepEqual(results, [o, o, 'bar', 'bar']);
   });
 
 });

--- a/test/query.js
+++ b/test/query.js
@@ -355,5 +355,12 @@ suite('query', function() {
     assert.deepEqual(jp.query({a: 1, b: 2, c: null}, '$..["a","b","c","d"]'), [1, 2, null]);
   });
 
+  test('circular reference', function() {
+    var obj = { foo: 'bar' };
+    obj.circularReference = obj;
+    var results = jp.query(obj, '$..*');
+    assert.deepEqual(results, ['bar', obj]);
+  });
+
 });
 


### PR DESCRIPTION
I ran into this issue today while dealing with a large object tree that contained circular references. Due to the recursive nature of the path I was using, the result was a `RangeError: Maximum call stack size exceeded`. For my particular use case, it would be preferable for jsonpath to be resilient to such cases by avoiding traversing circular references again.

My solution is keep a set of visited objects as the tree is traversed. If the same object shows up twice then `descend` avoids visiting it again.

Hope you find this useful! Let me know if somethings needs more work ❤️ 