### PR TITLE
Security Related Update for static-eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "esprima": "1.2.2",
     "jison": "0.4.13",
-    "static-eval": "0.2.3",
+    "static-eval": "2.0.0",
     "underscore": "1.7.0"
   },
   "browser": {


### PR DESCRIPTION
An issue with the static eval module could lead to arbitrary code execution. More details at: https://maustin.net/articles/2017-10/static_eval

Merged PR at: https://github.com/substack/static-eval/pull/18

I ran all test locally and it looks like there should be no issue upgrading to 2.0.0. 