### PR TITLE
Make jison a dev dependency and ship less files.

### DIFF
--- a/bin/generate_parser.js
+++ b/bin/generate_parser.js
@@ -1,8 +1,7 @@
 var JisonParser = require('jison').Parser;
-var grammar = require('../lib/grammar');
+var grammar = require('../include/grammar');
 
 var parser = new JisonParser(grammar);
 source = parser.generate()
 
 console.log(source)
-

--- a/include/grammar.js
+++ b/include/grammar.js
@@ -1,4 +1,4 @@
-var dict = require('./dict');
+var dict = require('../lib/dict');
 var fs = require('fs');
 var grammar = {
 
@@ -98,9 +98,8 @@ var grammar = {
                 [ 'Q_STRING',  "$$ = $1" ] ]
     }
 };
-if (fs.readFileSync) {
-  grammar.moduleInclude = fs.readFileSync(require.resolve("../include/module.js"));
-  grammar.actionInclude = fs.readFileSync(require.resolve("../include/action.js"));
-}
+
+grammar.moduleInclude = fs.readFileSync(require.resolve("./module.js"));
+grammar.actionInclude = fs.readFileSync(require.resolve("./action.js"));
 
 module.exports = grammar;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,3 @@
-var grammar = require('./grammar');
 var gparser = require('../generated/parser');
 
 var Parser = function() {
@@ -17,5 +16,4 @@ var Parser = function() {
 
 };
 
-Parser.grammar = grammar;
 module.exports = Parser;

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
     "test": "mocha -u tdd test && jscs lib && jshint lib",
     "generate": "node bin/generate_parser.js > generated/parser.js"
   },
+  "files": [
+    "lib",
+    "index.js",
+    "jsonpath.js",
+    "jsonpath.min.js"
+  ],
   "dependencies": {
     "esprima": "1.2.2",
-    "jison": "0.4.13",
     "static-eval": "2.0.2",
     "underscore": "1.7.0"
   },
@@ -22,6 +27,7 @@
     "grunt-browserify": "3.8.0",
     "grunt-cli": "0.1.13",
     "grunt-contrib-uglify": "0.9.1",
+    "jison": "0.4.13",
     "jscs": "1.10.0",
     "jshint": "2.6.0",
     "mocha": "2.1.0"


### PR DESCRIPTION
This PR makes the following changes:

* `jison` becomes a dev-depency. It's not used at runtime anyway.
* The grammar is no longer exposed on the parser.
* Ship only files in the npm which are necessary for the package to function.

Jison pulls in quite a few dependencies so this slims down the footprint of this package quite a bit.

Not exposing the grammar on the parser makes the code a bit smaller, should be especially beneficial in the browser.