### PR TITLE
Switch from underscore to lodash.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,6 @@ module.exports = function (grunt) {
                         'source-map',
                         'estraverse',
                         'escodegen',
-                        'underscore',
                         'reflect',
                         'JSONSelect',
                         './lib/aesprim.js'

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,7 +1,7 @@
 var aesprim = require('./aesprim');
 var slice = require('./slice');
 var _evaluate = require('static-eval');
-var _uniq = require('underscore').uniq;
+var uniqBy = require('lodash/uniqBy');
 
 // Property names that must never be accessible in expressions.
 // Mitigates prototype pollution and constructor escape attacks.
@@ -395,7 +395,7 @@ function evaluate(ast, scope) {
 
 function unique(results) {
   results = results.filter(function(d) { return d })
-  return _uniq(
+  return uniqBy(
     results,
     function(r) { return r.path.map(function(c) { return String(c).replace('-', '--') }).join('-') }
   );

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "esprima": "1.2.5",
-    "static-eval": "2.1.1",
-    "underscore": "1.13.6"
+    "lodash": "^4.18.1",
+    "static-eval": "2.1.1"
   },
   "browser": "./jsonpath.js",
   "alias": {


### PR DESCRIPTION
Lodash is more widely used these days so it deduplicates more easily.

Lodash has been great with semver compatibility and gets updated somewhat often so I kept the `^` for the version spec.

Fixes #160 #180 #200 #201