### PR TITLE
Another security related update for static-eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "esprima": "1.2.2",
     "jison": "0.4.13",
-    "static-eval": "2.0.0",
+    "static-eval": "2.0.1",
     "underscore": "1.7.0"
   },
   "browser": {


### PR DESCRIPTION
The package 'static-eval' has been deemed [vulnerable](https://www.npmjs.com/advisories/758).

This PR includes the newest version of static-eval with the patch for a 'Sandbox Breakout / Arbitrary Code Execution' vulnerability.

Ref: https://www.npmjs.com/advisories/758