### PR TITLE
Replace `@` and `$` with valid javascript names before evaluation 

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -239,8 +239,34 @@ function _traverse(passable) {
   }
 }
 
-function evaluate() {
-  try { return _evaluate.apply(this, arguments) }
+function rename_ast_literals(node, search, replace) {
+  if (node.type === 'Identifier') {
+    if (replace.includes(node.name)) {
+      throw new Error("Reserved name used in script: " + node.name);
+    }
+    var match = search.indexOf(node.name);
+    if (match >= 0) {
+      return {...node, name: replace[match]};
+    }
+  } else {
+    for (const [name, value] of Object.entries(node)) {
+      if (typeof(value) === 'object' && 'type' in value) {
+        node[name] = rename_ast_literals(value, search, replace);
+      }
+    }
+  }
+  return node;
+}
+
+function evaluate(ast, { '@': current, '$': root, ...objects }, ...extra) {
+  if (typeof(current) !== 'undefined') {
+    objects['__jsonpath_current'] = current
+  }
+  if (typeof(root) !== 'undefined') {
+    objects['__jsonpath_root'] = root
+  }
+  ast = rename_ast_literals(ast, ['@', '$'], ['__jsonpath_current', '__jsonpath_root'])
+  try { return _evaluate.call(this, ast, objects, ...extra) }
   catch (e) { }
 }
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -246,16 +246,15 @@ function rename_ast_literals(node, search, replace) {
     }
     var match = search.indexOf(node.name);
     if (match >= 0) {
-      return {...node, name: replace[match]};
+      node['name'] = replace[match];
     }
   } else {
     for (const [name, value] of Object.entries(node)) {
       if (typeof(value) === 'object' && 'type' in value) {
-        node[name] = rename_ast_literals(value, search, replace);
+        rename_ast_literals(value, search, replace);
       }
     }
   }
-  return node;
 }
 
 function evaluate(ast, { '@': current, '$': root, ...objects }, ...extra) {
@@ -265,7 +264,7 @@ function evaluate(ast, { '@': current, '$': root, ...objects }, ...extra) {
   if (typeof(root) !== 'undefined') {
     objects['__jsonpath_root'] = root
   }
-  ast = rename_ast_literals(ast, ['@', '$'], ['__jsonpath_current', '__jsonpath_root'])
+  rename_ast_literals(ast, ['@', '$'], ['__jsonpath_current', '__jsonpath_root'])
   try { return _evaluate.call(this, ast, objects, ...extra) }
   catch (e) { }
 }


### PR DESCRIPTION
 This is a simple yet safe traversal of the AST after it is parsed and before it is evaluated, replacing JsonPath spec-defined names `@` and `$` with valid names (`__jsonpath_current` and `__jsonpath_root`, but they could be any names).

This allows functions that are evaluatable statically by `static-eval` to work, e.g. have a script that does `(@.map(function(x) { x + 1 }))` as part of its computations. Previously, the evaluation of such functions failed, as the variable names are used inside static-eval to define a proper scope for the function, and this causes an error due to the variable names being invalid.

A simple example or test could be for example:
```js
jp.query({foo: [1, 2, 3]}, '$.foo[(@.findIndex(function(x) { return x == 2 }))]')
Error: Parse error on line 1:
$[undefined]
--^
Expecting 'STAR', 'SCRIPT_EXPRESSION', 'INTEGER', 'ARRAY_SLICE', 'FILTER_EXPRESSION', 'QQ_STRING', 'Q_STRING', got 'IDENTIFIER'
[…]
```

This should return the same as the following:
```js
jp.query({foo: [1, 2, 3]}, '$.foo[(@.indexOf(2))]')
[ 2 ]
```

With this PR it does:
```js
jp.query({foo: [1, 2, 3]}, '$.foo[(@.findIndex(function(x) { return x == 2 }))]')
[ 2 ]
```

This opens the door to more interesting stuff, e.g. find the first even number:
```js
jp.query({foo: [1, 2, 3]}, '$.foo[(@.findIndex(function(x) { return x % 2 == 0 }))]')
[ 2 ]
```