### PR TITLE
fix vuls: CVE-2023-26115 relate to word-wrap dependency of static-eval, fix by pump static-eval to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "esprima": "1.2.2",
-    "static-eval": "2.0.2",
+    "static-eval": "2.1.1",
     "underscore": "1.12.1"
   },
   "browser": "./jsonpath.js",


### PR DESCRIPTION
Hi, I use you library in my app, 
when I do code scanning with Snyk, it show that's a security issue in the dependencies

Its related to the word-wrap dependency of the static-eval (which is currently use by jsonpath) so I update the version of it.

Reference:
CVE relate to word-wrap: https://nvd.nist.gov/vuln/detail/CVE-2023-26115
Snyk report: https://security.snyk.io/package/npm/static-eval