### PR TITLE
Attempt to fix CVE-2026-1615 vulnerability

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -3,6 +3,152 @@ var slice = require('./slice');
 var _evaluate = require('static-eval');
 var _uniq = require('underscore').uniq;
 
+// Property names that must never be accessible in expressions.
+// Mitigates prototype pollution and constructor escape attacks.
+var UNSAFE_PROPERTY_NAMES = Object.create(null);
+
+/* jshint -W069: true */
+UNSAFE_PROPERTY_NAMES['constructor'] = true;
+UNSAFE_PROPERTY_NAMES['__proto__'] = true;
+UNSAFE_PROPERTY_NAMES['prototype'] = true;
+/* jshint -W069: false */
+
+function isUnsafePropertyName(name) {
+  return typeof name === 'string' && UNSAFE_PROPERTY_NAMES[name] === true;
+}
+
+function isSafeAst(ast) {
+  if (!ast || typeof ast !== 'object') return false;
+
+  function walk(node) {
+    if (!node || typeof node !== 'object' || !node.type) {
+      return false;
+    }
+
+    switch (node.type) {
+
+      // ===== SAFE TERMINALS =====
+
+      case 'Literal':
+        return true;
+
+      case 'Identifier':
+        // Only allow the special scope identifier
+        return node.name === '@';
+
+
+      // ===== PROPERTY ACCESS =====
+
+      case 'MemberExpression': {
+        if (!walk(node.object)) {
+          return false;
+        }
+
+        // Non-computed: obj.property
+        if (!node.computed && node.property.type === 'Identifier') {
+          if (isUnsafePropertyName(node.property.name)) {
+            return false;
+          }
+          return true;
+        }
+
+        // Computed: obj["property"]
+        if (node.computed) {
+          if (!walk(node.property)) {
+            return false;
+          }
+
+          if (
+            node.property.type === 'Literal' &&
+            isUnsafePropertyName(String(node.property.value))
+          ) {
+            return false;
+          }
+
+          return true;
+        }
+
+        return false;
+      }
+
+
+      // ===== EXPRESSIONS =====
+
+      case 'UnaryExpression':
+        return walk(node.argument);
+
+      case 'BinaryExpression':
+      case 'LogicalExpression':
+        return walk(node.left) && walk(node.right);
+
+      case 'ConditionalExpression':
+        return (
+          walk(node.test) &&
+          walk(node.consequent) &&
+          walk(node.alternate)
+        );
+
+      case 'ArrayExpression':
+        for (var i = 0; i < node.elements.length; i++) {
+          if (!walk(node.elements[i])) {
+            return false;
+          }
+        }
+        return true;
+
+      case 'ObjectExpression':
+        for (var j = 0; j < node.properties.length; j++) {
+          var prop = node.properties[j];
+
+          // Reject unsafe keys
+          if (
+            prop.key &&
+            (
+              (prop.key.type === 'Identifier' &&
+               isUnsafePropertyName(prop.key.name)) ||
+              (prop.key.type === 'Literal' &&
+               isUnsafePropertyName(String(prop.key.value)))
+            )
+          ) {
+            return false;
+          }
+
+          if (!walk(prop.value)) {
+            return false;
+          }
+        }
+        return true;
+
+
+      // ===== EXPLICITLY REJECT DANGEROUS TYPES =====
+      // Security: do not rely on default deny; list each code-execution / escape vector.
+
+      case 'CallExpression':
+      case 'NewExpression':
+      case 'FunctionExpression':
+      case 'ArrowFunctionExpression':
+      case 'ThisExpression':
+      case 'AssignmentExpression':
+      case 'UpdateExpression':
+      case 'SequenceExpression':
+      case 'TemplateLiteral':
+      case 'TemplateElement':
+      case 'TaggedTemplateExpression':
+      case 'ReturnStatement':
+      case 'ExpressionStatement':
+        return false;
+
+
+      // ===== DEFAULT DENY =====
+
+      default:
+        return false;
+    }
+  }
+
+  return walk(ast);
+}
+
 var Handlers = function() {
   return this.initialize.apply(this, arguments);
 }
@@ -239,8 +385,11 @@ function _traverse(passable) {
   }
 }
 
-function evaluate() {
-  try { return _evaluate.apply(this, arguments) }
+function evaluate(ast, scope) {
+  if (!isSafeAst(ast)) {
+    throw new Error('Unsafe expression: script and filter expressions may only access the current node (@) with safe property names');
+  }
+  try { return _evaluate(ast, scope) }
   catch (e) { }
 }
 

--- a/test/security.js
+++ b/test/security.js
@@ -48,4 +48,191 @@ suite('security', function() {
     }, /Unsafe key/);
     assert.equal(({}).polluted, undefined);
   });
+
+  suite('CVE-2026-1615: blocks code injection in filter/script expressions', function() {
+    var data = { a: {}, b: [1, 2, 3] };
+
+    test('rejects constructor access in filter expression', function() {
+      assert.throws(function() {
+        jp.query(data, '$[?(@.constructor)]');
+      }, /Unsafe expression/);
+    });
+
+    test('rejects constructor.constructor in filter expression', function() {
+      assert.throws(function() {
+        jp.query(data, '$[?(@.constructor.constructor)]');
+      }, /Unsafe expression/);
+    });
+
+    test('rejects chained constructor.constructor call: @.foo["constructor"]["constructor"](...)()', function() {
+      assert.throws(function() {
+        jp.query(data, '$[?(@.foo["constructor"]["constructor"]("return process")())]');
+      }, /Unsafe expression/);
+    });
+
+    test('rejects __proto__ access in filter expression', function() {
+      assert.throws(function() {
+        jp.query(data, '$[?(@.__proto__)]');
+      }, /Unsafe expression/);
+    });
+
+    test('rejects function call in filter expression', function() {
+      assert.throws(function() {
+        jp.query(data, '$[?(process.exit(1))]');
+      }, /Unsafe expression/);
+    });
+
+    test('rejects constructor access in script expression', function() {
+      var scriptData = { a: [1, 2, 3] };
+      assert.throws(function() {
+        jp.query(scriptData, '$[(@.constructor)]');
+      }, /Unsafe expression/);
+    });
+
+    test('allows safe filter expressions', function() {
+      var storeData = { store: { book: [ { price: 5 }, { price: 15 } ] } };
+      var results = jp.query(storeData, '$..book[?(@.price<10)]');
+      assert.deepEqual(results, [ { price: 5 } ]);
+    });
+
+    test('allows safe script expressions', function() {
+      var bookData = { book: [ { id: 1 }, { id: 2 }, { id: 3 } ] };
+      var results = jp.nodes(bookData, '$..book[(@.length-1)]');
+      assert.deepEqual(results[0].value, { id: 3 });
+    });
+
+    test('rejects bracket notation constructor: @["constructor"]', function() {
+      assert.throws(function() { jp.query(data, '$[?(@["constructor"])]'); }, /Unsafe expression/);
+    });
+
+    test('rejects bracket notation __proto__: @["__proto__"]', function() {
+      assert.throws(function() { jp.query(data, '$[?(@["__proto__"])]'); }, /Unsafe expression/);
+    });
+
+    test('rejects bracket notation prototype: @["prototype"]', function() {
+      assert.throws(function() { jp.query(data, '$[?(@["prototype"])]'); }, /Unsafe expression/);
+    });
+
+    test('rejects ObjectExpression with unsafe key: { "__proto__": @ }', function() {
+      assert.throws(function() { jp.query(data, '$[?({ "__proto__": @ })]'); }, /Unsafe expression|Unexpected token/);
+    });
+
+    test('rejects ObjectExpression with unsafe key: { "constructor": @ }', function() {
+      assert.throws(function() { jp.query(data, '$[?({ "constructor": @ })]'); }, /Unsafe expression|Unexpected token/);
+    });
+
+    test('rejects ObjectExpression with unsafe key: { "prototype": @ }', function() {
+      assert.throws(function() { jp.query(data, '$[?({ "prototype": @ })]'); }, /Unsafe expression|Unexpected token/);
+    });
+
+    test('rejects unicode escape constructor in bracket: @["\\u0063onstructor"]', function() {
+      assert.throws(function() { jp.query(data, '$[?(@["\\u0063onstructor"])]'); }, /Unsafe expression/);
+    });
+
+    test('rejects unicode escape __proto__ in bracket', function() {
+      var path = '$[?(@["\\u005f\\u005fproto\\u005f\\u005f"])]';
+      assert.throws(function() { jp.query(data, path); }, /Unsafe expression/);
+    });
+
+    test('rejects IIFE: (function(){return 1})()', function() {
+      assert.throws(function() { jp.query(data, '$[?((function(){return 1})())]'); }, /Unsafe expression/);
+    });
+
+    test('rejects direct function call: process.exit(1)', function() {
+      assert.throws(function() { jp.query(data, '$[?(process.exit(1))]'); }, /Unsafe expression/);
+    });
+
+    test('rejects require() call', function() {
+      assert.throws(function() { jp.query(data, '$[?(require("fs"))]'); }, /Unsafe expression/);
+    });
+
+    test('rejects eval() call', function() {
+      assert.throws(function() { jp.query(data, '$[?(eval("1"))]'); }, /Unsafe expression/);
+    });
+
+    test('rejects globalThis / global identifier', function() {
+      assert.throws(function() { jp.query(data, '$[?(globalThis)]'); }, /Unsafe expression/);
+      assert.throws(function() { jp.query(data, '$[?(global)]'); }, /Unsafe expression/);
+    });
+
+    test('rejects NewExpression: new Function("return 1")()', function() {
+      assert.throws(function() { jp.query(data, '$[?(new Function("return 1")())]'); }, /Unsafe expression/);
+    });
+
+    test('rejects JSFuck-style: [] ["filter"]["constructor"]', function() {
+      assert.throws(function() { jp.query(data, '$[?([]["filter"]["constructor"])]'); }, /Unsafe expression/);
+    });
+
+    test('rejects JSFuck-style constructor call (no @)', function() {
+      assert.throws(function() { jp.query(data, '$[?([]["filter"]["constructor"]("return 1")())]'); }, /Unsafe expression/);
+    });
+
+    test('rejects sequence expression: (1, process.exit)(1)', function() {
+      assert.throws(function() { jp.query(data, '$[?((1, process.exit)(1))]'); }, /Unsafe expression/);
+    });
+
+    test('rejects method call on @: @.valueOf()', function() {
+      assert.throws(function() { jp.query(data, '$[?(@.valueOf())]'); }, /Unsafe expression/);
+    });
+
+    test('rejects method call: @.toString()', function() {
+      assert.throws(function() { jp.query(data, '$[?(@.toString())]'); }, /Unsafe expression/);
+    });
+
+    test('rejects template literal in computed: @[`constructor`]', function() {
+      assert.throws(function() { jp.query(data, '$[?(@[`constructor`])]'); }, /Unsafe expression|Unexpected token|ILLEGAL/);
+    });
+
+    test('rejects tagged template (code execution vector)', function() {
+      assert.throws(function() { jp.query(data, '$[?(String.raw`x`)]'); }, /Unsafe expression|Unexpected token|ILLEGAL/);
+    });
+
+    test('rejects ArrowFunctionExpression', function() {
+      assert.throws(function() { jp.query(data, '$[?((()=>1)())]'); }, /Unsafe expression|Unexpected token/);
+    });
+
+    test('rejects ThisExpression (this)', function() {
+      assert.throws(function() { jp.query(data, '$[?(this)]'); }, /Unsafe expression/);
+    });
+
+    test('rejects script expression with constructor', function() {
+      assert.throws(function() { jp.query(data, '$[(@.constructor)]'); }, /Unsafe expression/);
+    });
+
+    test('rejects script expression with call', function() {
+      assert.throws(function() { jp.query(data, '$[((function(){return 0})())]'); }, /Unsafe expression/);
+    });
+
+    test('allows @.length (no call)', function() {
+      var r = jp.query(data, '$[?(@.length)]');
+      assert.ok(Array.isArray(r));
+    });
+
+    test('allows bracket with safe key: @["length"]', function() {
+      var r = jp.query(data, '$[?(@["length"])]');
+      assert.ok(Array.isArray(r));
+    });
+
+    test('allows @["@class"] (existing test pattern)', function() {
+      var d = { DIV: [{ '@class': 'value', val: 5 }] };
+      var r = jp.query(d, '$..DIV[?(@["@class"]=="value")]');
+      assert.deepEqual(r, d.DIV);
+    });
+
+    test('rejects prototype access in filter', function() {
+      assert.throws(function() { jp.query(data, '$[?(@.prototype)]'); }, /Unsafe expression/);
+    });
+
+    test('rejects comma/sequence that could hide call', function() {
+      assert.throws(function() { jp.query(data, '$[?((0, eval)("1"))]'); }, /Unsafe expression/);
+    });
+
+    test('rejects AssignmentExpression', function() {
+      assert.throws(function() { jp.query(data, '$[?((x=1)==1)]'); }, /Unsafe expression/);
+    });
+
+    test('rejects UpdateExpression (++, --)', function() {
+      assert.throws(function() { jp.query(data, '$[?(@.x++)]'); }, /Unsafe expression/);
+    });
+  });
 });


### PR DESCRIPTION
# Attempt to Fix CVE-2026-1615: Arbitrary code injection in JSON Path expressions

## Problem

The library is affected by **CVE-2026-1615** ([GHSA-87r5-mp6g-5w5j](https://github.com/advisories/GHSA-87r5-mp6g-5w5j)), mentioned on [Issue 196](https://github.com/dchester/jsonpath/issues/196). Script and filter expressions `?(...)` and `(...)` were passed to **static-eval** with only the `@` variable. static-eval is not a security boundary: it still evaluates **CallExpression** and allows dangerous property access (e.g. `constructor`, `__proto__`), so expressions like `@.constructor.constructor('return process')().exit()` could lead to **RCE** (Node) or **XSS** (browser) when paths come from untrusted input.

## Solution

### 1. AST allowlist

Before calling static-eval, the expression AST is validated with `isSafeAst()`. Only a fixed set of node types is allowed: `Literal`, `Identifier` (only `@`), `MemberExpression`, `UnaryExpression`, `BinaryExpression`, `LogicalExpression`, `ConditionalExpression`, `ArrayExpression`, `ObjectExpression`. Any other node type is rejected.

### 2. Unsafe property names

Access to **constructor**, **__proto__**, and **prototype** is blocked at every `MemberExpression` so the path cannot reach `Function` or alter the prototype. The unsafe set is stored in an object built with `Object.create(null)` and bracket assignment so that **`__proto__`** is a normal property (object literals treat `__proto__` specially and would not add it as a key).

### 3. Explicit reject list (audit-friendly)

Dangerous node types are **explicitly** rejected instead of relying only on default-deny:

- `CallExpression`, `NewExpression`, `FunctionExpression`, `ArrowFunctionExpression`
- `ThisExpression`, `AssignmentExpression`, `UpdateExpression`, `SequenceExpression`
- `TemplateLiteral`, `TemplateElement`, `TaggedTemplateExpression`
- `ReturnStatement`, `ExpressionStatement`

### 4. ObjectExpression keys

For `ObjectExpression`, property **keys** are validated (Identifier and Literal). Object literals with unsafe keys (e.g. `{ "__proto__": @ }`, `{ "constructor": @ }`) are rejected.

### 5. Single allowed variable

The only allowed identifier is **`@`**; all others (e.g. `process`, `eval`, `require`, `globalThis`) are rejected.

If the expression is not safe, evaluation is not performed and an error is thrown: *"Unsafe expression: script and filter expressions may only access the current node (@) with safe property names"*.

## Testing

- All **existing** tests (query, filter, script, parse, security, slice, stringify, sugar) still pass.
- New tests under **CVE-2026-1615** cover:
  - Constructor / __proto__ / prototype (dot and bracket, including unicode escapes).
  - Chained constructor escape: `@.foo["constructor"]["constructor"]("return process")()`.
  - ObjectExpression with unsafe keys: `{ "__proto__": @ }`, `{ "constructor": @ }`, `{ "prototype": @ }`.
  - Calls: `process.exit`, `require`, `eval`, IIFE, `new Function`, method calls on `@`.
  - JSFuck-style payloads, sequence/comma expressions, template literals, arrow functions, assignment/update expressions.
  - That safe expressions (e.g. `?(@.price<10)`, `$..book[(@.length-1)]`, `@["@class"]`) still work.

**139 tests** pass in total.

## Files changed

- **`lib/handlers.js`** — Safe AST check (`isSafeAst`), unsafe-property map (`Object.create(null)` + bracket assignment), explicit reject list, ObjectExpression key validation.
- **`test/security.js`** — CVE-2026-1615 suite with regression and bypass tests.

## Notes
JS is not my main language, so my apologies about any good-practice or patterns that I might miss here, I tried to solve the problem without generate any breaking change sanitizing the content that must be evaluated by the `static-eval`. 

Please let me know if this approach makes sense or if there are additional improvements I should consider to ensure the issue is properly and safely resolved.