### PR TITLE
Update underscore dependency version to ^1.13.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "esprima": "1.2.5",
     "static-eval": "2.1.1",
-    "underscore": "1.13.6"
+    "underscore": "^1.13.8"
   },
   "browser": "./jsonpath.js",
   "alias": {


### PR DESCRIPTION
This change is closing the #200 

vulnerability is patched in version 1.13.8.